### PR TITLE
Visualise and inspect neural net

### DIFF
--- a/neural_nets/graphs/edge.rb
+++ b/neural_nets/graphs/edge.rb
@@ -1,0 +1,21 @@
+module Graphs
+  class Edge
+    attr_reader :left, :right, :nodes
+    attr_accessor :value
+
+    def initialize(left:, right:, value:)
+      @left = left
+      @right = right
+      @value = value.to_f
+      @nodes = [@left, @right]
+    end
+
+    def as_json
+      {
+        left: left.as_json,
+        right: right.as_json,
+        value: value
+      }
+    end
+  end
+end

--- a/neural_nets/graphs/graph.rb
+++ b/neural_nets/graphs/graph.rb
@@ -1,0 +1,94 @@
+require "json"
+require_relative "edge"
+require_relative "node"
+
+module Graphs
+  class Graph
+    def self.load(path)
+      json = File.read(path)
+
+      edges = JSON.parse(json, symbolize_names: true).map do |edge|
+        left = Node.new(
+          value: edge[:left][:value],
+          layer: edge[:left][:layer],
+          neurone: edge[:left][:neurone]
+        )
+
+        right = Node.new(
+          value: edge[:right][:value],
+          layer: edge[:right][:layer],
+          neurone: edge[:right][:neurone]
+        )
+
+        Edge.new(left: left, right: right, value: edge[:value])
+      end
+
+      new(nil).tap { |graph| graph.instance_variable_set(:@edges, edges) }
+    end
+
+    def initialize(neural_net)
+      @neural_net = neural_net
+    end
+
+    def save(path)
+      File.write(path, JSON.pretty_generate(as_json))
+    end
+
+    def edges
+      @edges ||= build_graph
+    end
+
+    private
+
+    def as_json
+      edges.map(&:as_json)
+    end
+
+    def build_graph
+      activations = []
+      # Activation for layer L - 1 is stored as the input to the weights in
+      # layer L. We don't store the input layer activation so we'll have to
+      # pull it out of the first hidden layer's weights to rebuild it.
+      # Remember a neurone has a weight for each neurone in the previous layer.
+      input_activation = @neural_net
+        .layers
+        .first
+        .neurones
+        .first
+        .weights
+        .map(&:input)
+
+      activations << input_activation
+
+      # We do store the hidden and output layer activations
+      @neural_net.layers.map(&:neurones).each do |neurones|
+        activations << neurones.map(&:activation)
+      end
+
+      nodes = []
+
+      activations.each_with_index do |layer, i|
+        nodes << layer.map.with_index do |activation, j|
+          Node.new(value: activation, layer: i, neurone: j)
+        end
+      end
+
+      edges = []
+
+      nodes.each_cons(2) do |l1_nodes, l2_nodes|
+        l1_nodes.each do |l1_node|
+          l2_nodes.each do |l2_node|
+            edges << Edge.new(
+              left: l1_node,
+              right: l2_node,
+              value: @neural_net.layers[l2_node.layer - 1].neurones[l2_node.neurone].weights[l1_node.neurone].value
+            )
+          end
+        end
+      end
+
+      edges
+    end
+  end
+end
+

--- a/neural_nets/graphs/graphviz.rb
+++ b/neural_nets/graphs/graphviz.rb
@@ -1,0 +1,74 @@
+require "ruby-graphviz"
+
+module Graphs
+  class Graphviz
+    attr_reader :graph
+
+    def initialize(graph)
+      @graph = graph
+    end
+
+    def to_png(file_path)
+      graphviz = GraphViz.new(
+        :G,
+        rankdir: 'LR',
+        type: :digraph,
+        nodesep: 0.5,
+        ranksep: 100
+      )
+
+      graph.edges.each do |edge|
+         left_node = graphviz.add_nodes(
+           "L##{edge.left.layer}N##{edge.left.neurone}",
+           style: "filled",
+           color: value_to_color(edge.left.value),
+           label: edge.left.value.round(2).to_s,
+           fontcolor: font_colour(edge.left.value)
+         )
+
+         right_node = graphviz.add_nodes(
+           "L##{edge.right.layer}N##{edge.right.neurone}",
+           style: "filled",
+           color: value_to_color(edge.right.value),
+           label: edge.right.value.round(2).to_s,
+           fontcolor: font_colour(edge.right.value)
+         )
+
+         graphviz.add_edges(
+           left_node,
+           right_node,
+           color: red_green_gradient(edge.value)
+         )
+      end
+
+      graphviz.output(png: file_path)
+    end
+
+    private
+
+    # only use for activations
+    def value_to_color(value)
+      brightness = (value * 255).clamp(0, 255).round
+      hex_brightness = brightness.to_s(16).rjust(2, '0')
+      "##{hex_brightness * 3}"
+    end
+
+    def red_green_gradient(value)
+      value = value.clamp(-1.0, 1.0)
+
+      if value >= 0
+        # Green gradient (0 to 1 maps to #808080 -> #00FF00)
+        green_intensity = (value * 255).round
+        "#00#{green_intensity.to_s(16).rjust(2, '0')}00" # Green color
+      else
+        # Red gradient (-1 to 0 maps to #808080 -> #FF0000)
+        red_intensity = ((-value) * 255).round
+        "##{red_intensity.to_s(16).rjust(2, '0')}0000" # Red color
+      end
+    end
+
+    def font_colour(value)
+      value > 0.5 ? "black" : "white"
+    end
+  end
+end

--- a/neural_nets/graphs/node.rb
+++ b/neural_nets/graphs/node.rb
@@ -1,0 +1,19 @@
+module Graphs
+  class Node
+    attr_reader :value, :layer, :neurone
+
+    def initialize(value:, layer:, neurone:)
+      @value = value
+      @layer = layer
+      @neurone = neurone
+    end
+
+    def as_json
+      {
+        value: value,
+        layer: layer,
+        neurone: neurone
+      }
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability to dump an activated neural net to json, load it again
from json and graph it with graphviz.

Generating a graphviz image is slow, these images are large clocking in
at ~200mb. You may not want to do this during a trainning run so we
support storing the data required for generating an image to use at a
later date.

Usage:
```rb
  # make a prediction to set the activations
  neural_net.predict(example.image_bytes)
  # Store the activated neural net and weights to disk
  Graphs::Graph.new(neural_net).save("tmp/some-activation.json")
  # Load the activations and weights
  graph = Graphs::Graph.load("tmp/some-activation.json")
  # Genereate a (large) png of the network
  Graphs::Graphviz.new(graph).to_png("tmp/activations.png")
```

Might be useful for visualising how the weights change as the network
learns or seeing what the average activations are for a given digit.
